### PR TITLE
feat: Add multicall feature

### DIFF
--- a/01-defender-meta-txs/contracts/Registry.sol
+++ b/01-defender-meta-txs/contracts/Registry.sol
@@ -3,22 +3,24 @@ pragma solidity ^0.8.0;
 
 import "@openzeppelin/contracts/metatx/ERC2771Context.sol";
 import "@openzeppelin/contracts/metatx/MinimalForwarder.sol";
+import "@openzeppelin/contracts/utils/Multicall.sol";
 
-contract Registry is ERC2771Context {  
-  event Registered(address indexed who, string name);
 
-  mapping(address => string) public names;
-  mapping(string => address) public owners;
+contract Registry is ERC2771Context, Multicall {
+    event Registered(address indexed who, string name);
 
-  constructor(MinimalForwarder forwarder) // Initialize trusted forwarder
-    ERC2771Context(address(forwarder)) {
-  }
+    mapping(address => string) public names;
+    mapping(string => address) public owners;
 
-  function register(string memory name) external {
-    require(owners[name] == address(0), "Name taken");
-    address owner = _msgSender(); // Changed from msg.sender
-    owners[name] = owner;
-    names[owner] = name;
-    emit Registered(owner, name);
-  }
+    constructor(
+        MinimalForwarder forwarder // Initialize trusted forwarder
+    ) ERC2771Context(address(forwarder)) {}
+
+    function register(string memory name) public {
+        require(owners[name] == address(0), "Name taken");
+        address owner = _msgSender(); // Changed from msg.sender
+        owners[name] = owner;
+        names[owner] = name;
+        emit Registered(owner, name);
+    }
 }

--- a/01-defender-meta-txs/hardhat.config.js
+++ b/01-defender-meta-txs/hardhat.config.js
@@ -20,13 +20,5 @@ module.exports = {
     local: {
       url: 'http://localhost:8545'
     },
-    xdai: {
-      url: 'https://dai.poa.network',
-      accounts: [process.env.PRIVATE_KEY],
-    },
-    mumbai: {
-      url: 'https://matic-mumbai.chainstacklabs.com',
-      accounts: [process.env.PRIVATE_KEY],
-    }
   }
 };

--- a/01-defender-meta-txs/test/contracts/Registry.test.js
+++ b/01-defender-meta-txs/test/contracts/Registry.test.js
@@ -10,14 +10,14 @@ async function deploy(name, ...params) {
 describe("contracts/Registry", function() {
   beforeEach(async function() {
     this.forwarder = await deploy('MinimalForwarder');
-    this.registry = await deploy("Registry", this.forwarder.address);    
+    this.registry = await deploy("Registry", this.forwarder.address);
     this.accounts = await ethers.getSigners();
   });
 
   it("registers a name directly", async function() {
     const sender = this.accounts[1];
     const registry = this.registry.connect(sender);
-    
+
     const receipt = await registry.register('defender').then(tx => tx.wait());
     expect(receipt.events[0].event).to.equal('Registered');
 
@@ -25,18 +25,60 @@ describe("contracts/Registry", function() {
     expect(await registry.names(sender.address)).to.equal('defender');
   });
 
+  it("registers names directly", async function() {
+    const sender = this.accounts[1];
+    const registry = this.registry.connect(sender);
+    const interface = new ethers.utils.Interface([
+      "function register(string memory name) public",
+    ])
+    const calls = [
+      interface.encodeFunctionData("register", ["defender"]),
+      interface.encodeFunctionData("register", ["multicall-example"])
+    ]
+    const receipt = await registry.multicall(calls).then(tx => tx.wait());
+    expect(receipt.events[0].event).to.equal('Registered');
+
+    expect(await registry.owners('defender')).to.equal(sender.address);
+    expect(await registry.owners('multicall-example')).to.equal(sender.address);
+  });
+
+  it("registers names via a meta-tx", async function() {
+    const signer = this.accounts[2];
+    const relayer = this.accounts[3];
+    const forwarder = this.forwarder.connect(relayer);
+    const registry = this.registry;
+    const interface = new ethers.utils.Interface([
+      "function register(string memory name) public",
+      "function multicall(bytes[] calldata data) external",
+    ])
+    const calls = [
+      interface.encodeFunctionData("register", ["defender"]),
+      interface.encodeFunctionData("register", ["multicall-example"])
+    ]
+
+    const { request, signature } = await signMetaTxRequest(signer.provider, forwarder, {
+      from: signer.address,
+      to: registry.address,
+      data: registry.interface.encodeFunctionData('multicall', [calls]),
+    });
+
+    await forwarder.execute(request, signature).then(tx => tx.wait());
+
+    expect(await registry.owners('defender')).to.equal(signer.address);
+    expect(await registry.owners('multicall-example')).to.equal(signer.address);
+  });
+
   it("registers a name via a meta-tx", async function() {
     const signer = this.accounts[2];
     const relayer = this.accounts[3];
     const forwarder = this.forwarder.connect(relayer);
     const registry = this.registry;
-
     const { request, signature } = await signMetaTxRequest(signer.provider, forwarder, {
       from: signer.address,
       to: registry.address,
       data: registry.interface.encodeFunctionData('register', ['meta-txs']),
     });
-    
+
     await forwarder.execute(request, signature).then(tx => tx.wait());
 
     expect(await registry.owners('meta-txs')).to.equal(signer.address);


### PR DESCRIPTION
# objective 
- make possible to use multicall with metatransaction

# current problems 
multicall feature doesn't work as expected 

➜  01-defender-meta-txs git:(feat/multicall) npx hardhat test test/contracts/Registry.test.js

```js
  contracts/Registry
    ✓ registers a name directly (71ms)
    ✓ registers names directly (83ms)
    1) registers names via a meta-tx
    ✓ registers a name via a meta-tx (51ms)


  3 passing (1s)
  1 failing

  1) contracts/Registry
       registers names via a meta-tx:

      AssertionError: expected '0x0000000000000000000000000000000000000000' to equal '0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC'
      + expected - actual

      -0x0000000000000000000000000000000000000000
      +0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC

      at Context.<anonymous> (test/contracts/Registry.test.js:67:50)
      at processTicksAndRejections (node:internal/process/task_queues:96:5)
```